### PR TITLE
Add api.notifyDebounced to the store

### DIFF
--- a/examples/apps/ui-combobox/src/remote-combobox.js
+++ b/examples/apps/ui-combobox/src/remote-combobox.js
@@ -1,5 +1,9 @@
 import { Combobox } from "@inglorious/ui/combobox"
 
+const SEARCH_DEBOUNCE_MS = 300
+
+let fetchCount = 0
+
 export const RemoteCombobox = {
   ...Combobox,
 
@@ -11,10 +15,19 @@ export const RemoteCombobox = {
     api.notify(`#${entity.id}:optionsLoad`)
   },
 
-  async optionsLoad(entity, payload, api) {
+  searchChange(entity, searchTerm, api) {
+    Combobox.searchChange(entity, searchTerm, api)
+    api.notifyDebounced(
+      `#${entity.id}:optionsLoad`,
+      searchTerm,
+      SEARCH_DEBOUNCE_MS,
+    )
+  },
+
+  async optionsLoad(entity, searchTerm, api) {
     const entityId = entity.id
     entity.isLoading = true
-    const loadedOptions = await loadData()
+    const loadedOptions = await loadData(searchTerm)
     api.notify(`#${entityId}:optionsLoadSuccess`, loadedOptions)
   },
 
@@ -24,11 +37,22 @@ export const RemoteCombobox = {
   },
 }
 
-async function loadData() {
-  return await [
+async function loadData(searchTerm = "") {
+  fetchCount++
+  // eslint-disable-next-line no-console
+  console.log(`[RemoteCombobox] fetch #${fetchCount} for "${searchTerm}"`)
+
+  const allOptions = [
     { value: "cat", label: "Cat" },
     { value: "dog", label: "Dog" },
     { value: "seal", label: "Seal" },
     { value: "shark", label: "Shark", isDisabled: true },
   ]
+
+  const term = searchTerm.trim().toLowerCase()
+  if (!term) return allOptions
+
+  return allOptions.filter((option) =>
+    option.label.toLowerCase().includes(term),
+  )
 }

--- a/packages/store/src/api.js
+++ b/packages/store/src/api.js
@@ -62,6 +62,16 @@ export function createApi(store, extras) {
      * @returns {void}
      */
     notify: store.notify,
+    /**
+     * Notifies the store, but debounced: rapid calls sharing the same `type`
+     * collapse into a single notification fired `wait` ms after the last call.
+     * Use this to debounce a follow-up event from inside a handler.
+     * @param {string} type
+     * @param {any} [payload]
+     * @param {number} [wait]
+     * @returns {void}
+     */
+    notifyDebounced: store.notifyDebounced,
     ...extras,
   }
 }

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -1,4 +1,5 @@
 import { toCamelCase } from "@inglorious/utils/data-structures/string.js"
+import { debounce as createDebounce } from "@inglorious/utils/functions/functions.js"
 import { create } from "mutative"
 
 import { createApi } from "./api.js"
@@ -27,6 +28,7 @@ export function createStore({
   updateMode = "auto",
 } = {}) {
   const listeners = new Set()
+  const debouncers = new Map()
 
   const types = augmentTypes(originalTypes)
 
@@ -37,6 +39,7 @@ export function createStore({
     subscribe,
     update,
     notify,
+    notifyDebounced,
     dispatch, // needed for compatibility with Redux
     getTypes,
     getType,
@@ -157,6 +160,38 @@ export function createStore({
   function notify(type, payload) {
     // NOTE: it's important to invoke store.dispatch instead of dispatch, otherwise we cannot override it
     store.dispatch({ type, payload })
+  }
+
+  /**
+   * Notifies the store, but debounced: rapid calls sharing the same `type`
+   * collapse into a single notification, fired `wait` ms after the last call.
+   *
+   * This is the store-friendly way to use debouncing. Handlers receive a
+   * `mutative` draft that is revoked once the event tick ends, so you cannot
+   * debounce a handler's body directly (it would mutate a dead draft) — instead
+   * you debounce the *emission* of a follow-up event, which is always safe.
+   * The `type` and `payload` are snapshotted up front, so no draft is retained.
+   *
+   * The internal timer is keyed by `type` and removed as soon as it fires, so
+   * no per-event state lingers between bursts.
+   *
+   * @param {string} type - The event type to notify (e.g. `#combobox:optionsLoad`).
+   * @param {any} [payload] - The event payload; the most recent one wins.
+   * @param {number} [wait] - Milliseconds to wait after the last call (defaults to 0).
+   */
+  function notifyDebounced(type, payload, wait) {
+    let debounced = debouncers.get(type)
+
+    if (!debounced) {
+      debounced = createDebounce((latestPayload) => {
+        // NOTE: self-cleanup keeps the map bounded to events currently in flight
+        debouncers.delete(type)
+        store.notify(type, latestPayload)
+      }, wait)
+      debouncers.set(type, debounced)
+    }
+
+    debounced(payload)
   }
 
   /**

--- a/packages/store/src/store.test.js
+++ b/packages/store/src/store.test.js
@@ -1,6 +1,10 @@
-import { expect, test } from "vitest"
+import { afterEach, expect, test, vi } from "vitest"
 
 import { createStore } from "./store.js"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 test("it should process events by mutating state inside handlers", () => {
   const config = {
@@ -202,4 +206,91 @@ test("it should auto-create entities when autoCreateEntities is enabled", () => 
     id: "player1",
     type: "Player",
   })
+})
+
+test("it should collapse rapid debounced notifications into a single handler run", () => {
+  vi.useFakeTimers()
+
+  const config = {
+    types: {
+      Kitty: {
+        feed(entity) {
+          entity.mealCount = (entity.mealCount ?? 0) + 1
+        },
+      },
+    },
+    entities: {
+      kitty1: { type: "Kitty" },
+    },
+  }
+
+  const store = createStore(config)
+
+  store.notifyDebounced("feed", undefined, 100)
+  store.notifyDebounced("feed", undefined, 100)
+  store.notifyDebounced("feed", undefined, 100)
+
+  // nothing fires until the wait elapses
+  expect(store.getState().kitty1.mealCount).toBeUndefined()
+
+  vi.advanceTimersByTime(100)
+
+  // three rapid calls resulted in exactly one handler run
+  expect(store.getState().kitty1.mealCount).toBe(1)
+})
+
+test("it should notify with the most recent payload when debounced", () => {
+  vi.useFakeTimers()
+
+  const config = {
+    types: {
+      Kitty: {
+        setName(entity, name) {
+          entity.name = name
+        },
+      },
+    },
+    entities: {
+      kitty1: { type: "Kitty" },
+    },
+  }
+
+  const store = createStore(config)
+
+  store.notifyDebounced("setName", "Whiskers", 100)
+  store.notifyDebounced("setName", "Mittens", 100)
+
+  vi.advanceTimersByTime(100)
+
+  expect(store.getState().kitty1.name).toBe("Mittens")
+})
+
+test("it should debounce each event type independently", () => {
+  vi.useFakeTimers()
+
+  const config = {
+    types: {
+      Kitty: {
+        feed(entity) {
+          entity.isFed = true
+        },
+        pet(entity) {
+          entity.isHappy = true
+        },
+      },
+    },
+    entities: {
+      kitty1: { type: "Kitty" },
+    },
+  }
+
+  const store = createStore(config)
+
+  store.notifyDebounced("feed", undefined, 100)
+  store.notifyDebounced("pet", undefined, 100)
+
+  vi.advanceTimersByTime(100)
+
+  expect(store.getState().kitty1.isFed).toBe(true)
+  expect(store.getState().kitty1.isHappy).toBe(true)
 })

--- a/packages/store/types/api.d.ts
+++ b/packages/store/types/api.d.ts
@@ -25,6 +25,7 @@ export interface Api<
   select: <TResult>(selector: (state: TState) => TResult) => TResult
   dispatch: (event: Event) => void
   notify: (type: string, payload?: any) => void
+  notifyDebounced: (type: string, payload?: any, wait?: number) => void
   [key: string]: any // For middleware extras
 }
 

--- a/packages/store/types/store.d.ts
+++ b/packages/store/types/store.d.ts
@@ -79,6 +79,7 @@ export interface Store<
   subscribe: (listener: Listener) => Unsubscribe
   update: () => Event[]
   notify: (type: string, payload?: any) => void
+  notifyDebounced: (type: string, payload?: any, wait?: number) => void
   dispatch: (event: Event) => void
   getTypes: () => TypesConfig<TEntity>
   getType: (typeName: string) => EntityType<TEntity>


### PR DESCRIPTION
Debouncing the utils `debounce` inside a handler doesn't work: handlers run against a mutative draft that is revoked after the event tick, and a new debounced function is created on every call. Wrap it at the store level instead as `api.notifyDebounced(type, payload, wait)`, which debounces the event emission (never the draft) and snapshots type + payload up front.

Timers are keyed by event type and self-clean once they fire, so no per-event state lingers between bursts. A dedicated method (rather than a third arg on `notify`) avoids middlewares silently dropping the delay, since they redefine `notify` as (type, payload) => dispatch(...).

Wires the ui-combobox remote example to demonstrate it.